### PR TITLE
Clean up init.pp and fix parameters for newer versions of puppet

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,6 @@
 #
 class vswitch (
   $provider = $vswitch::params::provider
-) {
-  $cls = "vswitch::${provider}"
-  include $cls
+) inherits vswitch::params {
+  class {"vswitch::${provider}": }
 }


### PR DESCRIPTION
The params class wasn't being called causing errors on puppet runs.

I also cleaned up the call to avoid an un-necessary variable.
